### PR TITLE
Skills match tags bar

### DIFF
--- a/client/src/components/Skills.jsx
+++ b/client/src/components/Skills.jsx
@@ -12,7 +12,7 @@ function getSkillsInDescription(text, skillRegexes, defaultUser) {
   const textSpaced = normalizeForWordSearch(text);
   if (defaultUser.skills && defaultUser.skills.length > 0) {
     const skills = [...defaultUser.skills].map((skill) =>
-      skill.replace(/[^A-Za-z0-9-/+#]+/g, " "),
+      skill.replace(/[-/]+/g, " ").trim(),
     );
     return skills.filter((skill) => {
       const re = skillRegexes.get(skill);

--- a/client/src/components/Skills.jsx
+++ b/client/src/components/Skills.jsx
@@ -1,20 +1,24 @@
 import { defaultUser } from "../data/defaultUser";
 import { useMemo } from "react";
+// Description of the future job skill input validation:
+// Allowed characters are letters, digits, -, /, +, and #.
 
 function normalizeForWordSearch(str) {
-  // Description of the future job skill input validation:
-  // Allowed characters are letters, digits, +, and #. Use spaces instead of other special characters. Such skills as 'Data-Science' or 'Broker/realtor', will still be found.
   return (" " + str + " ")
-    .replace(/[^A-Za-z0-9+#]+/g, " ")
+    .replace(/[^A-Za-z0-9-/+#]+/g, " ")
     .replace(/\s+/g, " ");
 }
 function getSkillsInDescription(text, skillRegexes, defaultUser) {
   const textSpaced = normalizeForWordSearch(text);
-  const skills = defaultUser.skills;
-  return skills.filter((skill) => {
-    const re = skillRegexes.get(skill);
-    return re ? re.test(textSpaced) : false;
-  });
+  if (defaultUser.skills && defaultUser.skills.length > 0) {
+    const skills = [...defaultUser.skills].map((skill) =>
+      skill.replace(/[^A-Za-z0-9-/+#]+/g, " "),
+    );
+    return skills.filter((skill) => {
+      const re = skillRegexes.get(skill);
+      return re ? re.test(textSpaced) : false;
+    });
+  }
 }
 
 export default function Skills({ item }) {

--- a/client/src/components/Skills.jsx
+++ b/client/src/components/Skills.jsx
@@ -1,7 +1,7 @@
 import { defaultUser } from "../data/defaultUser";
 import { useMemo } from "react";
 // Description of the future job skill input validation:
-// Allowed characters are letters, digits, -, /, +, and #.
+// Allowed characters are letters, digits, whitespace, -, /, +, and #.
 
 function normalizeForWordSearch(str) {
   return (" " + str + " ")

--- a/client/src/components/Skills.jsx
+++ b/client/src/components/Skills.jsx
@@ -5,7 +5,7 @@ import { useMemo } from "react";
 
 function normalizeForWordSearch(str) {
   return (" " + str + " ")
-    .replace(/[^A-Za-z0-9-/+#]+/g, " ")
+    .replace(/[^A-Za-z0-9+#]+/g, " ")
     .replace(/\s+/g, " ");
 }
 function getSkillsInDescription(text, skillRegexes, defaultUser) {

--- a/client/src/components/Skills.jsx
+++ b/client/src/components/Skills.jsx
@@ -3,16 +3,26 @@ import { useMemo } from "react";
 // Description of the future job skill input validation:
 // Allowed characters are letters, digits, whitespace, -, /, +, and #.
 
-function normalizeForWordSearch(str) {
+function normalizeDescription(str) {
   return (" " + str + " ")
     .replace(/[^A-Za-z0-9+#]+/g, " ")
     .replace(/\s+/g, " ");
 }
+function normalizeSkills(skill) {
+  if (typeof skill === "string") {
+    return skill.replace(/[-/\s]+/g, " ").trim();
+  }
+  return "";
+}
+function escapeForRegex(skill) {
+  return skill.replace(/[.*+?^${}()|[\]\\#]/g, "\\$&");
+}
+
 function getSkillsInDescription(text, skillRegexes, defaultUser) {
-  const textSpaced = normalizeForWordSearch(text);
+  const textSpaced = normalizeDescription(text);
   if (defaultUser.skills && defaultUser.skills.length > 0) {
     const skills = [...defaultUser.skills].map((skill) =>
-      skill.replace(/[-/]+/g, " ").trim(),
+      normalizeSkills(skill),
     );
     return skills.filter((skill) => {
       const re = skillRegexes.get(skill);
@@ -22,16 +32,17 @@ function getSkillsInDescription(text, skillRegexes, defaultUser) {
 }
 
 export default function Skills({ item }) {
-  const skills = defaultUser.skills;
-  const skillRegexes = useMemo(() => {
+  const { skills, skillRegexes } = useMemo(() => {
+    const skillsList = Array.isArray(defaultUser.skills)
+      ? defaultUser.skills.map((s) => normalizeSkills(s)).filter(Boolean)
+      : [];
     const map = new Map();
-    const escapeForRegex = (s) => s.replace(/[.*+?^${}()|[\]\\#]/g, "\\$&");
-    skills.forEach((skill) => {
+    skillsList.forEach((skill) => {
       const escaped = escapeForRegex(skill);
       map.set(skill, new RegExp(" " + escaped + " ", "i"));
     });
-    return map;
-  }, [skills]);
+    return { skills: skillsList, skillRegexes: map };
+  }, [defaultUser.skills]);
   const skillsInDescription = getSkillsInDescription(
     item.descriptionText || "",
     skillRegexes,

--- a/client/src/data/defaultUser.js
+++ b/client/src/data/defaultUser.js
@@ -45,7 +45,7 @@ export const defaultUser = {
     "Public speaking",
     "C++",
     "C#",
-    "Data Science",
+    "Data-Science",
     "Data analysis",
   ],
 };


### PR DESCRIPTION
Once again, I updated the skill match, so for now, those allowed characters in the skills are:
// Allowed characters are letters, digits, whitespace, -, /, +, and #.
It should go into the validation form.

Also, I updated the replacement mechanics, so the matches for the skills such as 'React/Native', or 'Data-Scientist', will still be found even if they are written with whitespace:  'React Native', or 'Data Scientist' in the job description.