### PR TITLE
Profile address rest changes

### DIFF
--- a/client/src/components/AddressSettings.jsx
+++ b/client/src/components/AddressSettings.jsx
@@ -2,17 +2,18 @@ import { UseSettings } from "../context/SettingsContext";
 
 export default function AddressSettings({
   saveProfileSettings,
-  streetInputRefExt,
-  houseInputRefExt,
-  cityInputRefExt,
-  countryInputRefExt,
+  streetInputRef,
+  houseInputRef,
+  cityInputRef,
+  countryInputRef,
 }) {
   const { settings } = UseSettings();
 
-  const streetInputRefInt = streetInputRefExt;
-  const houseInputRefInt = houseInputRefExt;
-  const cityInputRefInt = cityInputRefExt;
-  const countryInputRefInt = countryInputRefExt;
+  // use the refs passed from the parent (Profile)
+  const streetInputRefInt = streetInputRef;
+  const houseInputRefInt = houseInputRef;
+  const cityInputRefInt = cityInputRef;
+  const countryInputRefInt = countryInputRef;
 
   function pressEnterKey(e) {
     if (e.key === "Enter") {

--- a/client/src/components/AddressSettings.jsx
+++ b/client/src/components/AddressSettings.jsx
@@ -1,8 +1,29 @@
 import { UseSettings } from "../context/SettingsContext";
 
-export default function AddressSettings() {
+export default function AddressSettings({
+  saveProfileSettings,
+  streetInputRefExt,
+  houseInputRefExt,
+  cityInputRefExt,
+  countryInputRefExt,
+}) {
   const { settings } = UseSettings();
 
+  const streetInputRefInt = streetInputRefExt;
+  const houseInputRefInt = houseInputRefExt;
+  const cityInputRefInt = cityInputRefExt;
+  const countryInputRefInt = countryInputRefExt;
+
+  function pressEnterKey(e) {
+    if (e.key === "Enter") {
+      saveProfileSettings(
+        streetInputRefInt,
+        houseInputRefInt,
+        cityInputRefInt,
+        countryInputRefInt,
+      );
+    }
+  }
   return (
     <div className="mb-6">
       <label className="block text-sm font-medium text-gray-900 mb-3">
@@ -12,33 +33,45 @@ export default function AddressSettings() {
         <div>
           <label className="block text-xs text-gray-600 mb-1">Street</label>
           <input
+            id="streetInput"
+            ref={streetInputRefInt}
             type="text"
             defaultValue={settings.address.street}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onKeyDown={pressEnterKey}
           />
         </div>
         <div>
           <label className="block text-xs text-gray-600 mb-1">House no.</label>
           <input
+            id="houseInput"
+            ref={houseInputRefInt}
             type="text"
             defaultValue={settings.address.houseNumber}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onKeyDown={pressEnterKey}
           />
         </div>
         <div>
           <label className="block text-xs text-gray-600 mb-1">City</label>
           <input
+            id="cityInput"
+            ref={cityInputRefInt}
             type="text"
             defaultValue={settings.address.city}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onKeyDown={pressEnterKey}
           />
         </div>
         <div>
           <label className="block text-xs text-gray-600 mb-1">Country</label>
           <input
+            id="countryInput"
+            ref={countryInputRefInt}
             type="text"
             defaultValue={settings.address.country}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onKeyDown={pressEnterKey}
           />
         </div>
       </div>

--- a/client/src/components/AddressSettings.jsx
+++ b/client/src/components/AddressSettings.jsx
@@ -8,18 +8,14 @@ export default function AddressSettings({
   countryInputRef,
 }) {
   const { settings } = UseSettings();
-  const streetInputRefInt = streetInputRef;
-  const houseInputRefInt = houseInputRef;
-  const cityInputRefInt = cityInputRef;
-  const countryInputRefInt = countryInputRef;
 
   function pressEnterKey(e) {
     if (e.key === "Enter") {
       saveProfileSettings(
-        streetInputRefInt,
-        houseInputRefInt,
-        cityInputRefInt,
-        countryInputRefInt,
+        streetInputRef,
+        houseInputRef,
+        cityInputRef,
+        countryInputRef,
       );
     }
   }
@@ -33,7 +29,7 @@ export default function AddressSettings({
           <label className="block text-xs text-gray-600 mb-1">Street</label>
           <input
             id="streetInput"
-            ref={streetInputRefInt}
+            ref={streetInputRef}
             type="text"
             defaultValue={settings.address.street}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -44,7 +40,7 @@ export default function AddressSettings({
           <label className="block text-xs text-gray-600 mb-1">House no.</label>
           <input
             id="houseInput"
-            ref={houseInputRefInt}
+            ref={houseInputRef}
             type="text"
             defaultValue={settings.address.houseNumber}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -55,7 +51,7 @@ export default function AddressSettings({
           <label className="block text-xs text-gray-600 mb-1">City</label>
           <input
             id="cityInput"
-            ref={cityInputRefInt}
+            ref={cityInputRef}
             type="text"
             defaultValue={settings.address.city}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
@@ -66,7 +62,7 @@ export default function AddressSettings({
           <label className="block text-xs text-gray-600 mb-1">Country</label>
           <input
             id="countryInput"
-            ref={countryInputRefInt}
+            ref={countryInputRef}
             type="text"
             defaultValue={settings.address.country}
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"

--- a/client/src/components/AddressSettings.jsx
+++ b/client/src/components/AddressSettings.jsx
@@ -8,8 +8,6 @@ export default function AddressSettings({
   countryInputRef,
 }) {
   const { settings } = UseSettings();
-
-  // use the refs passed from the parent (Profile)
   const streetInputRefInt = streetInputRef;
   const houseInputRefInt = houseInputRef;
   const cityInputRefInt = cityInputRef;

--- a/client/src/components/SkillsSettings.jsx
+++ b/client/src/components/SkillsSettings.jsx
@@ -20,8 +20,7 @@ export default function SkillsSettings() {
   function addSkill() {
     const skillInput = skillInputRef.current;
     if (!skillInput) return;
-    const rawValue = skillInput.value || "";
-    const newSkill = cleanUpText(rawValue);
+    const newSkill = cleanUpText(skillInput.value || "");
 
     const validationError = validateSkillInput({ text: newSkill, skills });
     if (validationError) {

--- a/client/src/components/SkillsSettings.jsx
+++ b/client/src/components/SkillsSettings.jsx
@@ -7,7 +7,6 @@ import { cleanUpText } from "../util/cleanUpText";
 
 export default function SkillsSettings() {
   const skillInputRef = useRef(null);
-  const skillsListRef = useRef(null);
   const [alert, setAlert] = useState({ type: "", message: "" });
   const { settings, setSettings } = UseSettings();
   const { skills } = settings;
@@ -87,7 +86,7 @@ export default function SkillsSettings() {
         <AlertMessage type={alert.type} message={alert.message} />
       )}
       {/* Skills List */}
-      <div id="skillsList" ref={skillsListRef}>
+      <div id="skillsList">
         {(skills || []).map((s, idx) => (
           <div
             key={`${s.skill}-${idx}`}

--- a/client/src/context/FavoritesContext.jsx
+++ b/client/src/context/FavoritesContext.jsx
@@ -21,4 +21,4 @@ export const FavoritesProvider = ({ children }) => {
   );
 };
 
-export const useFavorites = () => useContext(FavoritesContext);
+export const UseFavorites = () => useContext(FavoritesContext);

--- a/client/src/pages/MyFavorites/MyFavorites.jsx
+++ b/client/src/pages/MyFavorites/MyFavorites.jsx
@@ -1,10 +1,10 @@
 import { UseJobs } from "../../context/JobsContext";
-import { useFavorites } from "../../context/FavoritesContext";
+import { UseFavorites } from "../../context/FavoritesContext";
 import JobCard from "../../components/JobCard/JobCard";
 
 export default function MyFavorites() {
   const { allJobs } = UseJobs();
-  const { favorites, toggleFavorite } = useFavorites();
+  const { favorites, toggleFavorite } = UseFavorites();
 
   const favoriteJobs = allJobs.filter((job) => favorites[job.id]);
 

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -204,7 +204,7 @@ export default function Profile() {
           <input
             id="confirmPasswordInput"
             ref={confirmPasswordInputRef}
-            type="text"
+            type="password"
             placeholder="Write the same password again"
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             onKeyDown={pressEnterKey}

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -109,7 +109,13 @@ export default function Profile() {
     });
   }
   function pressEnterKey(e) {
-    if (e.key === "Enter") saveProfileSettings(streetInputRef, houseInputRef, cityInputRef, countryInputRef);
+    if (e.key === "Enter")
+      saveProfileSettings(
+        streetInputRef,
+        houseInputRef,
+        cityInputRef,
+        countryInputRef,
+      );
   }
   return (
     <div className="content-container">

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -109,7 +109,7 @@ export default function Profile() {
     });
   }
   function pressEnterKey(e) {
-    if (e.key === "Enter") saveProfileSettings();
+    if (e.key === "Enter") saveProfileSettings(streetInputRef, houseInputRef, cityInputRef, countryInputRef);
   }
   return (
     <div className="content-container">

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -107,7 +107,6 @@ export default function Profile() {
       };
       return newSettings;
     });
-    console.log("newSettings:", settings);
   }
   function pressEnterKey(e) {
     if (e.key === "Enter") saveProfileSettings();

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 import { defaultUser } from "../../data/defaultUser";
 import SkillsSettings from "../../components/SkillsSettings";
 import AddressSettings from "../../components/AddressSettings";
+import { UseSettings } from "../../context/SettingsContext";
 
 export default function Profile() {
   const nameInputRef = useRef(null);
@@ -11,6 +12,8 @@ export default function Profile() {
   const houseInputRef = useRef(null);
   const cityInputRef = useRef(null);
   const countryInputRef = useRef(null);
+  const { settings } = UseSettings();
+  const { skills } = settings;
 
   function saveProfileSettings(
     streetRef = "",
@@ -38,6 +41,9 @@ export default function Profile() {
       } else {
         console.log("Passwords do not match.");
       }
+    }
+    if (skills) {
+      console.log("Skills:", skills);
     }
   }
   function pressEnterKey(e) {

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -1,10 +1,14 @@
-import { useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { defaultUser } from "../../data/defaultUser";
 import SkillsSettings from "../../components/SkillsSettings";
 import AddressSettings from "../../components/AddressSettings";
+import AlertMessage from "../../components/AlertMessage";
 import { UseSettings } from "../../context/SettingsContext";
+import { cleanUpText } from "../../util/cleanUpText";
+import { validateAddressTextInputs } from "../../util/addressTextsValidation";
 
 export default function Profile() {
+  const [alert, setAlert] = useState({ type: "", message: "" });
   const firstNameInputRef = useRef(null);
   const lastNameInputRef = useRef(null);
   const passwordInputRef = useRef(null);
@@ -16,38 +20,92 @@ export default function Profile() {
   const { settings } = UseSettings();
   const { skills } = settings;
 
+  useEffect(() => {
+    if (alert.message && skills) {
+      setAlert({ type: "", message: "" });
+    }
+  }, [skills]);
+
+  // Placeholder function for saving settings
+  // If called without args, default to the local refs defined above so
+  // pressing Enter from inputs in this component still works.
   function saveProfileSettings(
-    streetRef = "",
-    houseRef = "",
-    cityRef = "",
-    countryRef = "",
+    // streetRef = streetInputRef,
+    // houseRef = houseInputRef,
+    // cityRef = cityInputRef,
+    // countryRef = countryInputRef,
+    streetInputRef,
+    houseInputRef,
+    cityInputRef,
+    countryInputRef,
   ) {
-    // Placeholder function for saving settings
-    const firstName = firstNameInputRef.current
-      ? firstNameInputRef.current.value
-      : "";
-    const lastName = lastNameInputRef.current
-      ? lastNameInputRef.current.value
-      : "";
-    const password = passwordInputRef.current
-      ? passwordInputRef.current.value
-      : "";
-    const confirmPassword = confirmPasswordInputRef.current
-      ? confirmPasswordInputRef.current.value
-      : "";
-    const street = streetRef.current ? streetRef.current.value : "";
-    const house = houseRef.current ? houseRef.current.value : "";
-    const city = cityRef.current ? cityRef.current.value : "";
-    const country = countryRef.current ? countryRef.current.value : "";
+    // console.log(streetRef, houseRef, cityRef, countryRef);
+    let firstName = firstNameInputRef.current;
+    let lastName = lastNameInputRef.current;
+    let password = passwordInputRef.current;
+    let confirmPassword = confirmPasswordInputRef.current;
+    // let street = streetRef.current;
+    // let house = houseRef.current;
+    // let city = cityRef.current;
+    // let country = countryRef.current;
+    let street = streetInputRef.current;
+    let house = houseInputRef.current;
+    let city = cityInputRef.current;
+    let country = countryInputRef.current;
+    if (
+      !firstName ||
+      !lastName ||
+      !password ||
+      !confirmPassword ||
+      !street ||
+      !house ||
+      !city ||
+      !country
+    )
+      return;
+    // First and Last Name
+    firstName = cleanUpText(firstName.value || "");
+    lastName = cleanUpText(lastName.value || "");
     console.log("Saving settings for:", firstName, lastName);
-    console.log("Address:", { street, house, city, country });
+    // Passwords
+    password = password.value || "";
+    confirmPassword = confirmPassword.value || "";
     if (password || confirmPassword) {
+      console.log("password, confirmPassword", password, confirmPassword);
       if (password === confirmPassword) {
         console.log("Password updated.");
       } else {
         console.log("Passwords do not match.");
       }
     }
+    // Address
+    street = cleanUpText(street.value || "");
+    console.log("street:", street);
+    house = cleanUpText(house.value || "");
+    city = cleanUpText(city.value || "");
+    country = cleanUpText(country.value || "");
+    const streetValidationError = validateAddressTextInputs({
+      text: street,
+    });
+    const cityValidationError = validateAddressTextInputs({
+      text: city,
+    });
+    const countryValidationError = validateAddressTextInputs({
+      text: country,
+      type: "country",
+    });
+    if (
+      streetValidationError ||
+      cityValidationError ||
+      countryValidationError
+    ) {
+      setAlert(
+        streetValidationError || cityValidationError || countryValidationError,
+      );
+      return;
+    }
+    console.log("Address:", { street, house, city, country });
+    // Skills
     if (skills) {
       console.log("Skills:", skills);
     }
@@ -168,21 +226,28 @@ export default function Profile() {
       />
       <SkillsSettings />
       {/* <!-- Save Button --> */}
-      <div className="flex justify-end mb-8">
-        <button
-          id="saveBtn"
-          onClick={() =>
-            saveProfileSettings(
-              streetInputRef,
-              houseInputRef,
-              cityInputRef,
-              countryInputRef,
-            )
-          }
-          className="px-8 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition font-medium"
-        >
-          Save
-        </button>
+      <div className="flex items-center justify-end mb-8 space-x-4">
+        {alert.message && (
+          <div className="md:w-auto">
+            <AlertMessage type={alert.type} message={alert.message} />
+          </div>
+        )}
+        <div>
+          <button
+            id="saveBtn"
+            onClick={() =>
+              saveProfileSettings(
+                streetInputRef,
+                houseInputRef,
+                cityInputRef,
+                countryInputRef,
+              )
+            }
+            className="px-8 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition font-medium"
+          >
+            Save
+          </button>
+        </div>
       </div>
       <hr className="border-gray-300 mb-8" />
       {/* <!-- Profile Management Section --> */}

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -63,7 +63,8 @@ export default function Profile() {
       if (password === confirmPassword) {
         console.log("Password updated.");
       } else {
-        console.log("Passwords do not match.");
+        setAlert({ type: "error", message: "Passwords do not match." });
+        return;
       }
     }
     // Address

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -1,8 +1,48 @@
+import { useRef } from "react";
 import { defaultUser } from "../../data/defaultUser";
 import SkillsSettings from "../../components/SkillsSettings";
 import AddressSettings from "../../components/AddressSettings";
 
 export default function Profile() {
+  const nameInputRef = useRef(null);
+  const passwordInputRef = useRef(null);
+  const confirmPasswordInputRef = useRef(null);
+  const streetInputRef = useRef(null);
+  const houseInputRef = useRef(null);
+  const cityInputRef = useRef(null);
+  const countryInputRef = useRef(null);
+
+  function saveProfileSettings(
+    streetRef = "",
+    houseRef = "",
+    cityRef = "",
+    countryRef = "",
+  ) {
+    // Placeholder function for saving settings
+    const name = nameInputRef.current ? nameInputRef.current.value : "";
+    const password = passwordInputRef.current
+      ? passwordInputRef.current.value
+      : "";
+    const confirmPassword = confirmPasswordInputRef.current
+      ? confirmPasswordInputRef.current.value
+      : "";
+    const street = streetRef.current ? streetRef.current.value : "";
+    const house = houseRef.current ? houseRef.current.value : "";
+    const city = cityRef.current ? cityRef.current.value : "";
+    const country = countryRef.current ? countryRef.current.value : "";
+    console.log("Saving settings for:", name);
+    console.log("Address:", { street, house, city, country });
+    if (password || confirmPassword) {
+      if (password === confirmPassword) {
+        console.log("Password updated.");
+      } else {
+        console.log("Passwords do not match.");
+      }
+    }
+  }
+  function pressEnterKey(e) {
+    if (e.key === "Enter") saveProfileSettings();
+  }
   return (
     <div className="content-container">
       {/* <!-- Page Title --> */}
@@ -41,9 +81,12 @@ export default function Profile() {
               Name
             </label>
             <input
+              id="nameInput"
+              ref={nameInputRef}
               type="text"
               defaultValue={defaultUser.name}
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="flex-grow px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              onKeyDown={pressEnterKey}
             />
           </div>
         </div>
@@ -58,9 +101,12 @@ export default function Profile() {
             Set New Password
           </label>
           <input
+            id="newPasswordInput"
+            ref={passwordInputRef}
             type="password"
             placeholder="Type 8 characters or more"
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onKeyDown={pressEnterKey}
           />
         </div>
         <div>
@@ -68,9 +114,12 @@ export default function Profile() {
             Confirm Password
           </label>
           <input
+            id="confirmPasswordInput"
+            ref={confirmPasswordInputRef}
             type="text"
             placeholder="Write the same password again"
             className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            onKeyDown={pressEnterKey}
           />
         </div>
       </div>
@@ -78,11 +127,28 @@ export default function Profile() {
       <hr className="border-gray-300 mb-8" />
       {/* Settings Section */}
       <h2 className="text-lg font-semibold text-gray-900 mb-6">Settings</h2>
-      <AddressSettings />
+      <AddressSettings
+        saveProfileSettings={saveProfileSettings}
+        streetInputRef={streetInputRef}
+        houseInputRef={houseInputRef}
+        cityInputRef={cityInputRef}
+        countryInputRef={countryInputRef}
+      />
       <SkillsSettings />
       {/* <!-- Save Button --> */}
       <div className="flex justify-end mb-8">
-        <button className="px-8 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition font-medium">
+        <button
+          id="saveBtn"
+          onClick={() =>
+            saveProfileSettings(
+              streetInputRef,
+              houseInputRef,
+              cityInputRef,
+              countryInputRef,
+            )
+          }
+          className="px-8 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 transition font-medium"
+        >
           Save
         </button>
       </div>

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -5,7 +5,8 @@ import AddressSettings from "../../components/AddressSettings";
 import { UseSettings } from "../../context/SettingsContext";
 
 export default function Profile() {
-  const nameInputRef = useRef(null);
+  const firstNameInputRef = useRef(null);
+  const lastNameInputRef = useRef(null);
   const passwordInputRef = useRef(null);
   const confirmPasswordInputRef = useRef(null);
   const streetInputRef = useRef(null);
@@ -22,7 +23,12 @@ export default function Profile() {
     countryRef = "",
   ) {
     // Placeholder function for saving settings
-    const name = nameInputRef.current ? nameInputRef.current.value : "";
+    const firstName = firstNameInputRef.current
+      ? firstNameInputRef.current.value
+      : "";
+    const lastName = lastNameInputRef.current
+      ? lastNameInputRef.current.value
+      : "";
     const password = passwordInputRef.current
       ? passwordInputRef.current.value
       : "";
@@ -33,7 +39,7 @@ export default function Profile() {
     const house = houseRef.current ? houseRef.current.value : "";
     const city = cityRef.current ? cityRef.current.value : "";
     const country = countryRef.current ? countryRef.current.value : "";
-    console.log("Saving settings for:", name);
+    console.log("Saving settings for:", firstName, lastName);
     console.log("Address:", { street, house, city, country });
     if (password || confirmPassword) {
       if (password === confirmPassword) {
@@ -58,6 +64,7 @@ export default function Profile() {
       {/* <!-- Profile Section with Avatar and Name --> */}
       <div className="mb-8">
         <div className="flex items-start space-x-4">
+          {/* <!-- Avatar with the editing/updating button --> */}
           <div className="relative">
             <div className="w-20 h-20 bg-gray-300 rounded flex-shrink-0 overflow-hidden">
               <img
@@ -83,17 +90,36 @@ export default function Profile() {
             </button>
           </div>
           <div className="flex-grow">
+            {/* <!-- First and Last Name --> */}
             <label className="block text-sm font-medium text-gray-900 mb-2">
               Name
             </label>
-            <input
-              id="nameInput"
-              ref={nameInputRef}
-              type="text"
-              defaultValue={defaultUser.name}
-              className="flex-grow px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-              onKeyDown={pressEnterKey}
-            />
+            <div className="grid grid-cols-2 gap-4 mb-3">
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">
+                  First Name
+                </label>
+                <input
+                  ref={firstNameInputRef}
+                  type="text"
+                  defaultValue={defaultUser.name}
+                  className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  onKeyDown={pressEnterKey}
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-gray-600 mb-1">
+                  Last Name
+                </label>
+                <input
+                  ref={lastNameInputRef}
+                  type="text"
+                  defaultValue={defaultUser.name}
+                  className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  onKeyDown={pressEnterKey}
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/pages/User/Profile.jsx
+++ b/client/src/pages/User/Profile.jsx
@@ -6,6 +6,7 @@ import AlertMessage from "../../components/AlertMessage";
 import { UseSettings } from "../../context/SettingsContext";
 import { cleanUpText } from "../../util/cleanUpText";
 import { validateAddressTextInputs } from "../../util/addressTextsValidation";
+import { validateHouseNoInput } from "../../util/addressHouseNoValidation";
 
 export default function Profile() {
   const [alert, setAlert] = useState({ type: "", message: "" });
@@ -17,37 +18,24 @@ export default function Profile() {
   const houseInputRef = useRef(null);
   const cityInputRef = useRef(null);
   const countryInputRef = useRef(null);
-  const { settings } = UseSettings();
-  const { skills } = settings;
+  const { settings, setSettings } = UseSettings();
 
   useEffect(() => {
-    if (alert.message && skills) {
+    if (alert.message && settings) {
       setAlert({ type: "", message: "" });
     }
-  }, [skills]);
+  }, [settings]);
 
-  // Placeholder function for saving settings
-  // If called without args, default to the local refs defined above so
-  // pressing Enter from inputs in this component still works.
   function saveProfileSettings(
-    // streetRef = streetInputRef,
-    // houseRef = houseInputRef,
-    // cityRef = cityInputRef,
-    // countryRef = countryInputRef,
     streetInputRef,
     houseInputRef,
     cityInputRef,
     countryInputRef,
   ) {
-    // console.log(streetRef, houseRef, cityRef, countryRef);
     let firstName = firstNameInputRef.current;
     let lastName = lastNameInputRef.current;
     let password = passwordInputRef.current;
     let confirmPassword = confirmPasswordInputRef.current;
-    // let street = streetRef.current;
-    // let house = houseRef.current;
-    // let city = cityRef.current;
-    // let country = countryRef.current;
     let street = streetInputRef.current;
     let house = houseInputRef.current;
     let city = cityInputRef.current;
@@ -80,7 +68,6 @@ export default function Profile() {
     }
     // Address
     street = cleanUpText(street.value || "");
-    console.log("street:", street);
     house = cleanUpText(house.value || "");
     city = cleanUpText(city.value || "");
     country = cleanUpText(country.value || "");
@@ -94,21 +81,33 @@ export default function Profile() {
       text: country,
       type: "country",
     });
+    const houseValidationError = validateHouseNoInput({ text: house });
     if (
       streetValidationError ||
       cityValidationError ||
-      countryValidationError
+      countryValidationError ||
+      houseValidationError
     ) {
       setAlert(
-        streetValidationError || cityValidationError || countryValidationError,
+        streetValidationError ||
+          cityValidationError ||
+          countryValidationError ||
+          houseValidationError,
       );
       return;
     }
-    console.log("Address:", { street, house, city, country });
-    // Skills
-    if (skills) {
-      console.log("Skills:", skills);
-    }
+    setSettings((prev) => {
+      const newSettings = { ...prev };
+      newSettings.address = {
+        ...(newSettings.address || {}),
+        street,
+        house,
+        city,
+        country,
+      };
+      return newSettings;
+    });
+    console.log("newSettings:", settings);
   }
   function pressEnterKey(e) {
     if (e.key === "Enter") saveProfileSettings();

--- a/client/src/pages/openPositions/OpenPositions.jsx
+++ b/client/src/pages/openPositions/OpenPositions.jsx
@@ -6,6 +6,7 @@ import { sortAndFilterJobs } from "../../util/sortingAndFiltering";
 import { UseJobs } from "../../context/JobsContext";
 import { UseFavorites } from "../../context/FavoritesContext";
 import "./OpenPositions.css";
+import SkillsSettings from "../../components/SkillsSettings";
 
 export default function OpenPositions() {
   const { allJobs, searchTerm, showResults } = UseJobs();
@@ -76,6 +77,7 @@ export default function OpenPositions() {
 
   return (
     <div className="open-positions content-container">
+      <SkillsSettings />
       <div className="job-filters-bar">
         <div className="filters-container">
           <div className="filter-dropdowns">

--- a/client/src/pages/openPositions/OpenPositions.jsx
+++ b/client/src/pages/openPositions/OpenPositions.jsx
@@ -4,12 +4,12 @@ import JobCard from "../../components/JobCard/JobCard";
 import Pagination from "../../components/Pagination/Pagination";
 import { sortAndFilterJobs } from "../../util/sortingAndFiltering";
 import { UseJobs } from "../../context/JobsContext";
-import { useFavorites } from "../../context/FavoritesContext";
+import { UseFavorites } from "../../context/FavoritesContext";
 import "./OpenPositions.css";
 
 export default function OpenPositions() {
   const { allJobs, searchTerm, showResults } = UseJobs();
-  const { favorites, toggleFavorite } = useFavorites();
+  const { favorites, toggleFavorite } = UseFavorites();
 
   const [currentPage, setCurrentPage] = useState(1);
   const jobsPerPage = 5;

--- a/client/src/util/addressHouseNoValidation.js
+++ b/client/src/util/addressHouseNoValidation.js
@@ -9,7 +9,7 @@ export function validateHouseNoInput({ text }) {
   const isNumbersOnly = /^\d+$/.test(text);
   if (!isNumbersOnly) {
     return {
-      type: "warning",
+      type: "error",
       message:
         "House number must contain only numbers, no letters or special characters.",
     };

--- a/client/src/util/addressTextsValidation.js
+++ b/client/src/util/addressTextsValidation.js
@@ -1,4 +1,12 @@
-export function validateAddressTextInputs({ text }) {
+export function validateAddressTextInputs({ text, type = "general" }) {
+  if (type === "country" && text !== "Netherlands") {
+    return {
+      type: "error",
+      message:
+        "Sorry, at the moment our app only supports addresses in the Netherlands.",
+    };
+  }
+
   if (text === "") {
     return {
       type: "error",


### PR DESCRIPTION
The skill and addresses sections on the profile page are fully functional. The skills section is also duplicated at the top of the "Open positions" page.

The username and password fields are ready to be used to update credentials, but they have not yet switched to authentication logic. There is no validation on those fields at the moment.

We need to decide how many buttons we need: "Clear all settings", "Clear Skills", or both, but on different pages?