### PR TITLE
Real time parallel job search

### DIFF
--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -20,10 +20,16 @@ export const searchJobs = async (req, res) => {
     const searchWords = search_terms
       .split(new RegExp("[\\s\\-.'/]+"))
       .filter(Boolean);
-    for (const jobWord of searchWords) {
-      const fetchedJobs = isSearchReal
-        ? await realJobSearch(jobWord)
-        : fakeJobSearch(jobWord);
+    // Fetch results for all search words concurrently
+    const fetchPromises = searchWords.map((jobWord) =>
+      isSearchReal
+        ? realJobSearch(jobWord)
+        : Promise.resolve(fakeJobSearch(jobWord)),
+    );
+
+    const fetchedJobsArrays = await Promise.all(fetchPromises);
+
+    for (const fetchedJobs of fetchedJobsArrays) {
       for (const job of fetchedJobs) {
         if (job.id && !aggregatedJobsIdsSet.has(job.id)) {
           aggregatedJobs.push(processJobPost(job));

--- a/server/src/controllers/jobData.js
+++ b/server/src/controllers/jobData.js
@@ -3,7 +3,7 @@ import { realJobSearch } from "./realJobSearch.js";
 import { fakeJobSearch } from "./fakeJobSearch.js";
 import processJobPost from "../util/processJobPost.js";
 
-const isSearchReal = false; // Set to true to enable real job search
+const isSearchReal = true; // Set to true to enable real job search
 
 export const searchJobs = async (req, res) => {
   try {

--- a/server/src/controllers/realJobSearch.js
+++ b/server/src/controllers/realJobSearch.js
@@ -46,7 +46,7 @@ export const realJobSearch = async (
     if (Array.isArray(apiResult)) {
       aggregated.push(...apiResult);
     } else {
-      logError("Unexpected API response shape", apiResult);
+      logError(`Unexpected API response shape: ${JSON.stringify(apiResult)}`);
     }
   });
 

--- a/server/src/controllers/realJobSearch.js
+++ b/server/src/controllers/realJobSearch.js
@@ -30,8 +30,9 @@ export const realJobSearch = async (
       if (!apiResponse.ok) {
         const errorText = await apiResponse.text();
         logError(
-          `Linkedin API Error: ${apiResponse.status} - ${apiResponse.statusText}`,
+          `Linkedin API Error status: ${apiResponse.status} - ${apiResponse.statusText}`,
         );
+        logError(`Linkedin API Error: ${errorText}`);
         throw new Error(`Failed to fetch from Linkedin API: ${errorText}`);
       }
       return apiResponse.json();

--- a/server/src/controllers/realJobSearch.js
+++ b/server/src/controllers/realJobSearch.js
@@ -31,7 +31,6 @@ export const realJobSearch = async (
         const errorText = await apiResponse.text();
         logError(
           `Linkedin API Error: ${apiResponse.status} - ${apiResponse.statusText}`,
-          errorText,
         );
         throw new Error(`Failed to fetch from Linkedin API: ${errorText}`);
       }

--- a/server/src/controllers/realJobSearch.js
+++ b/server/src/controllers/realJobSearch.js
@@ -8,46 +8,48 @@ export const realJobSearch = async (
   initialOffset = 0,
 ) => {
   const aggregated = [];
-  let offset = initialOffset;
+  // Build offsets for concurrent requests
+  const offsets = Array.from(
+    { length: maxIterations },
+    (_, i) => initialOffset + i * limit,
+  );
 
-  for (let i = 0; i < maxIterations; i++) {
+  const options = {
+    method: "GET",
+    headers: {
+      "x-rapidapi-key": process.env.X_RAPIDAPI_KEY,
+      "x-rapidapi-host": "linkedin-job-search-api.p.rapidapi.com",
+    },
+  };
+
+  const fetchPromises = offsets.map((offset) => {
     const url = `https://linkedin-job-search-api.p.rapidapi.com/active-jb-7d?limit=${limit}&offset=${offset}&title_filter=${encodeURIComponent(
       jobWord,
     )}&location_filter=${encodeURIComponent(location)}&description_type=text`;
 
-    const options = {
-      method: "GET",
-      headers: {
-        "x-rapidapi-key": process.env.X_RAPIDAPI_KEY,
-        "x-rapidapi-host": "linkedin-job-search-api.p.rapidapi.com",
-      },
-    };
+    return fetch(url, options).then(async (apiResponse) => {
+      if (!apiResponse.ok) {
+        const errorText = await apiResponse.text();
+        logError(
+          `Linkedin API Error: ${apiResponse.status} - ${apiResponse.statusText}`,
+          errorText,
+        );
+        throw new Error(`Failed to fetch from Linkedin API: ${errorText}`);
+      }
+      return apiResponse.json();
+    });
+  });
 
-    const apiResponse = await fetch(url, options);
-    if (!apiResponse.ok) {
-      const errorText = await apiResponse.text();
-      logError(
-        `Linkedin API Error: ${apiResponse.status} - ${apiResponse.statusText}`,
-        errorText,
-      );
-      throw new Error(`Failed to fetch from Linkedin API: ${errorText}`);
+  // Run all requests concurrently and aggregate results
+  const results = await Promise.all(fetchPromises);
+
+  results.forEach((apiResult) => {
+    if (Array.isArray(apiResult)) {
+      aggregated.push(...apiResult);
+    } else if (apiResult) {
+      aggregated.push(apiResult);
     }
-    const apiResult = await apiResponse.json();
-
-    const items = apiResult || [];
-    if (items.length === 0) {
-      break;
-    }
-
-    aggregated.push(...items);
-
-    if (items.length < limit) {
-      // last page
-      break;
-    }
-
-    offset += limit;
-  }
+  });
 
   return aggregated;
 };

--- a/server/src/controllers/realJobSearch.js
+++ b/server/src/controllers/realJobSearch.js
@@ -3,17 +3,16 @@ import { logError } from "../util/logging.js";
 export const realJobSearch = async (
   jobWord,
   location = "Netherlands",
-  limit = 100,
+  limit = 80,
   maxIterations = 2,
   initialOffset = 0,
 ) => {
   const aggregated = [];
-  // Build offsets for concurrent requests
-  const offsets = Array.from(
-    { length: maxIterations },
-    (_, i) => initialOffset + i * limit,
-  );
 
+  const offsets = [];
+  for (let i = 0; i < maxIterations; i++) {
+    offsets.push(initialOffset + i * limit);
+  }
   const options = {
     method: "GET",
     headers: {

--- a/server/src/controllers/realJobSearch.js
+++ b/server/src/controllers/realJobSearch.js
@@ -45,8 +45,8 @@ export const realJobSearch = async (
   results.forEach((apiResult) => {
     if (Array.isArray(apiResult)) {
       aggregated.push(...apiResult);
-    } else if (apiResult) {
-      aggregated.push(apiResult);
+    } else {
+      logError('Unexpected API response shape', apiResult);
     }
   });
 

--- a/server/src/controllers/realJobSearch.js
+++ b/server/src/controllers/realJobSearch.js
@@ -45,7 +45,7 @@ export const realJobSearch = async (
     if (Array.isArray(apiResult)) {
       aggregated.push(...apiResult);
     } else {
-      logError('Unexpected API response shape', apiResult);
+      logError("Unexpected API response shape", apiResult);
     }
   });
 


### PR DESCRIPTION
I changed the value of the switch to the real job fetch 80 job two times(iterations) per jobWord.

Also, I changed the fetch mechanism to use the same approach as travel details fetching use now: concurrent fetching with the Promise.all method instead of consecutive for() { await...). The logic inside those functions stays the same.